### PR TITLE
Implement persistence for the list of registered users

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -61,6 +61,14 @@
                 "type": "bool",
                 "default": false,
                 "help_text": "If this is activated when the user type '/gather-plugin on' the plugin try to find a meeting instead of waiting to the next scheduled."
+            },
+            {
+              "key": "AllowInfoForEveryone",
+              "display_name": "Info for Everyone",
+              "type": "bool",
+              "help_text": "If this is activated, any user can type '/gather-plugin info' to see who is currently signed up. Otherwise, only system users can.",
+              "placeholder": "",
+              "default": false
             }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -18,10 +18,11 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	Cron         string
-	CustomCron   string
-	InitText     string
-	FirstMeeting bool
+	Cron                 string
+	CustomCron           string
+	InitText             string
+	FirstMeeting         bool
+	AllowInfoForEveryone bool
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -82,6 +82,14 @@ const manifestStr = `
         "help_text": "If this is activated when the user type '/gather-plugin on' the plugin try to find a meeting instead of waiting to the next scheduled.",
         "placeholder": "",
         "default": false
+      },
+      {
+        "key": "AllowInfoForEveryone",
+        "display_name": "Info for Everyone",
+        "type": "bool",
+        "help_text": "If this is activated, any user can type '/gather-plugin info' to see who is currently signed up. Otherwise, only system users can.",
+        "placeholder": "",
+        "default": false
       }
     ]
   }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"math/rand"
 	"strings"
 	"sync"
@@ -57,6 +59,20 @@ func (p *Plugin) OnActivate() error {
 	}
 
 	p.botUserID = botUserID
+
+	// Deserialize user data
+	userData, err := p.API.KVGet("users")
+	if err != nil {
+		return err
+	}
+	if userData != nil {
+		var users []string
+		err := json.Unmarshal(userData, &users)
+		if err != nil {
+			return err
+		}
+		p.users = users;
+	}
 
 	return p.API.RegisterCommand(&model.Command{
 		Trigger:          "gather-plugin",
@@ -216,10 +232,27 @@ func startMeeting(p *Plugin, userID string, pairUserID string) {
 	p.API.CreatePost(post)
 }
 
-// OnDeactivate desativate plugin
+// OnDeactivate deactivate plugin
 func (p *Plugin) OnDeactivate() error {
 	p.cron.Remove(p.cronEntryID)
 	p.cron.Stop()
+
+	// Persist currently signed-up users
+	userData, err := json.Marshal(p.users)
+	if err != nil {
+		p.API.LogError(fmt.Sprintf("Failed to serialize users: %s", err.Error()))
+		return err
+	}
+
+	// Cannot reuse `err` here, because `KVSet` returns a pointer, not an interface,
+	// which when cast to the `error` interface of `err`, will result in a non-nil value.
+	err2 := p.API.KVSet("users", userData)
+
+	if err2 != nil {
+		p.API.LogError(fmt.Sprintf("Failed to persist users: %s", err2.Error()))
+		return err2
+	}
+
 	return nil
 }
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -295,6 +295,19 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			Text:         "Gather plugin deactivate.",
 		}, nil
 	} else if split[1] == "info" {
+		config := p.getConfiguration()
+		caller, err := p.API.GetUser(args.UserId)
+		if err != nil {
+			return nil, err
+		}
+
+		if !(config.AllowInfoForEveryone || caller.IsSystemAdmin()) {
+			return &model.CommandResponse{
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+				Text:         "Only system admins can do this.",
+			}, nil
+		}
+
 		var msg strings.Builder
 
 		msg.WriteString("Users signed up for coffee meetings:\n")

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -308,15 +309,21 @@ func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*mo
 			}, nil
 		}
 
-		var msg strings.Builder
-
-		msg.WriteString("Users signed up for coffee meetings:\n")
+		var lines []string
 		for _, userId := range p.users {
 			user, err := p.API.GetUser(userId)
 			if err != nil {
 				return nil, err
 			}
-			msg.WriteString(fmt.Sprintf(" - %s %s (@%s)\n", user.FirstName, user.LastName, user.Username))
+			lines = append(lines, fmt.Sprintf(" - %s %s (@%s)\n", user.FirstName, user.LastName, user.Username))
+		}
+
+		sort.Strings(lines)
+
+		var msg strings.Builder
+		msg.WriteString("Users signed up for coffee meetings:\n")
+		for _, line := range lines {
+			msg.WriteString(line)
 		}
 
 		return &model.CommandResponse{


### PR DESCRIPTION
This PR adds
- persistence for the registered user, so that they are remembered across a server restart
- a command to view who has signed up for it (optionally limited to only system users)

That way, the plugin can even be used without a hitch for longer times when the occasional Mattermost updates need to be applied.

Fixes https://github.com/juanfran/mattermost-gather-users/issues/1.